### PR TITLE
General ruby convention clean-up ahead of submission

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -5,6 +5,7 @@ class Game
               :home_team_id,
               :away_goals,
               :home_goals
+
   def initialize(data)
     @id = data[:game_id].to_i
     @season = data[:season]

--- a/lib/game_manager.rb
+++ b/lib/game_manager.rb
@@ -5,7 +5,9 @@ require_relative './supportable'
 class GameManager
   include Mathable
   include Supportable
+
   attr_reader :games
+
   def initialize(file_location)
     all(file_location)
   end

--- a/lib/game_teams.rb
+++ b/lib/game_teams.rb
@@ -7,6 +7,7 @@ class GameTeam
               :goals,
               :shots,
               :tackles
+
   def initialize(data)
     @game_id = data[:game_id].to_i
     @team_id = data[:team_id]

--- a/lib/game_teams_manager.rb
+++ b/lib/game_teams_manager.rb
@@ -5,7 +5,9 @@ require_relative './supportable'
 class GameTeamsManager
   include Mathable
   include Supportable
+
   attr_reader :game_teams
+
   def initialize(file_location)
     all(file_location)
   end

--- a/lib/mathable.rb
+++ b/lib/mathable.rb
@@ -1,7 +1,5 @@
 module Mathable
-
   def percentage(numerator, denominator, round)
     (numerator.to_f / denominator).round(round)
   end
-
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -4,14 +4,15 @@ class StatTracker
   attr_reader :game_manager,
               :team_manager,
               :game_teams_manager
+
+  def self.from_csv(file_locations)
+    new(file_locations)
+  end
+
   def initialize(file_locations)
     @game_manager       = GameManager.new(file_locations[:games])
     @team_manager       = TeamManager.new(file_locations[:teams])
     @game_teams_manager = GameTeamsManager.new(file_locations[:game_teams])
-  end
-
-  def self.from_csv(file_locations)
-    new(file_locations)
   end
 
   def highest_total_score

--- a/lib/supportable.rb
+++ b/lib/supportable.rb
@@ -1,5 +1,4 @@
 module Supportable
-
   def counter_sub_hash
     Hash.new {|stats, key| stats[key] = Hash.new {|sums, stat| sums[stat] = 0}}
   end
@@ -30,5 +29,4 @@ module Supportable
     end
     win_pct_by_category
   end
-
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -5,6 +5,7 @@ class Team
               :abbreviation,
               :link,
               :team_data
+
   def initialize(data)
     @team_id = data["team_id"]
     @franchise_id = data["franchiseId"]

--- a/lib/team_manager.rb
+++ b/lib/team_manager.rb
@@ -2,6 +2,7 @@ require 'csv'
 
 class TeamManager
   attr_reader :teams
+
   def initialize(file_location)
     all(file_location)
   end

--- a/test/game_teams_manager_test.rb
+++ b/test/game_teams_manager_test.rb
@@ -16,11 +16,11 @@ class GameTeamsManagerTest < Minitest::Test
   end
 
   def test_total_goals_by_team
-    expected = {:game_count=>516, :goals=>1128}
+    expected = {:game_count => 516, :goals => 1128}
     assert_equal expected, @game_teams_manager.total_goals_by_team["28"]
-    expected = {:game_count=>258, :goals=>549}
+    expected = {:game_count => 258, :goals => 549}
     assert_equal expected, @game_teams_manager.total_goals_by_team('away')["28"]
-    expected = {:game_count=>258, :goals=>579}
+    expected = {:game_count => 258, :goals => 579}
     assert_equal expected, @game_teams_manager.total_goals_by_team('home')["28"]
   end
 
@@ -31,218 +31,236 @@ class GameTeamsManagerTest < Minitest::Test
   end
 
   def test_best_offense
-    @game_teams_manager.expects(:avg_goals_by_team).returns({"3"=>2.13,
-    "6"=>2.26,
-    "5"=>2.29,
-    "17"=>2.06,
-    "16"=>2.16,
-    "9"=>2.11,
-    "8"=>2.05,
-    "30"=>2.12,
-    "26"=>2.08,
-    "19"=>2.11,
-    "24"=>2.2,
-    "2"=>2.18,
-    "15"=>2.21,
-    "20"=>2.07,
-    "14"=>2.22,
-    "28"=>2.19,
-    "4"=>2.04,
-    "21"=>2.07,
-    "25"=>2.22,
-    "13"=>2.06,
-    "18"=>2.15,
-    "10"=>2.11,
-    "29"=>2.17,
-    "52"=>2.17,
-    "54"=>2.34,
-    "1"=>1.94,
-    "23"=>1.97,
-    "12"=>2.04,
-    "27"=>2.02,
-    "7"=>1.84,
-    "22"=>2.05,
-    "53"=>1.89})
+    @game_teams_manager.expects(:avg_goals_by_team).returns(
+      {
+        "3" => 2.13,
+        "6" => 2.26,
+        "5" => 2.29,
+        "17" => 2.06,
+        "16" => 2.16,
+        "9" => 2.11,
+        "8" => 2.05,
+        "30" => 2.12,
+        "26" => 2.08,
+        "19" => 2.11,
+        "24" => 2.2,
+        "2" => 2.18,
+        "15" => 2.21,
+        "20" => 2.07,
+        "14" => 2.22,
+        "28" => 2.19,
+        "4" => 2.04,
+        "21" => 2.07,
+        "25" => 2.22,
+        "13" => 2.06,
+        "18" => 2.15,
+        "10" => 2.11,
+        "29" => 2.17,
+        "52" => 2.17,
+        "54" => 2.34,
+        "1" => 1.94,
+        "23" => 1.97,
+        "12" => 2.04,
+        "27" => 2.02,
+        "7" => 1.84,
+        "22" => 2.05,
+        "53" => 1.89
+      })
     assert_equal "54", @game_teams_manager.best_offense
   end
 
   def test_worst_offense
-    @game_teams_manager.expects(:avg_goals_by_team).returns({"3"=>2.13,
-    "6"=>2.26,
-    "5"=>2.29,
-    "17"=>2.06,
-    "16"=>2.16,
-    "9"=>2.11,
-    "8"=>2.05,
-    "30"=>2.12,
-    "26"=>2.08,
-    "19"=>2.11,
-    "24"=>2.2,
-    "2"=>2.18,
-    "15"=>2.21,
-    "20"=>2.07,
-    "14"=>2.22,
-    "28"=>2.19,
-    "4"=>2.04,
-    "21"=>2.07,
-    "25"=>2.22,
-    "13"=>2.06,
-    "18"=>2.15,
-    "10"=>2.11,
-    "29"=>2.17,
-    "52"=>2.17,
-    "54"=>2.34,
-    "1"=>1.94,
-    "23"=>1.97,
-    "12"=>2.04,
-    "27"=>2.02,
-    "7"=>1.84,
-    "22"=>2.05,
-    "53"=>1.89})
+    @game_teams_manager.expects(:avg_goals_by_team).returns(
+      {
+        "3" => 2.13,
+        "6" => 2.26,
+        "5" => 2.29,
+        "17" => 2.06,
+        "16" => 2.16,
+        "9" => 2.11,
+        "8" => 2.05,
+        "30" => 2.12,
+        "26" => 2.08,
+        "19" => 2.11,
+        "24" => 2.2,
+        "2" => 2.18,
+        "15" => 2.21,
+        "20" => 2.07,
+        "14" => 2.22,
+        "28" => 2.19,
+        "4" => 2.04,
+        "21" => 2.07,
+        "25" => 2.22,
+        "13" => 2.06,
+        "18" => 2.15,
+        "10" => 2.11,
+        "29" => 2.17,
+        "52" => 2.17,
+        "54" => 2.34,
+        "1" => 1.94,
+        "23" => 1.97,
+        "12" => 2.04,
+        "27" => 2.02,
+        "7" => 1.84,
+        "22" => 2.05,
+        "53" => 1.89
+      })
     assert_equal "7", @game_teams_manager.worst_offense
   end
 
   def test_highest_scoring_visitor
-    @game_teams_manager.expects(:avg_goals_by_team).returns({"3"=>2.15,
-    "6"=>2.25,
-    "5"=>2.18,
-    "17"=>2.04,
-    "16"=>2.1,
-    "9"=>2.01,
-    "8"=>2.01,
-    "30"=>2.01,
-    "26"=>2.03,
-    "19"=>2.04,
-    "24"=>2.14,
-    "2"=>2.1,
-    "15"=>2.2,
-    "20"=>1.93,
-    "14"=>2.12,
-    "28"=>2.13,
-    "4"=>1.97,
-    "21"=>1.91,
-    "25"=>2.12,
-    "13"=>1.95,
-    "18"=>2.05,
-    "10"=>1.95,
-    "29"=>2.12,
-    "52"=>2.04,
-    "54"=>2.1,
-    "1"=>1.9,
-    "12"=>2.02,
-    "23"=>1.94,
-    "22"=>2.03,
-    "7"=>1.88,
-    "27"=>1.85,
-    "53"=>1.85})
+    @game_teams_manager.expects(:avg_goals_by_team).returns(
+      {
+        "3" => 2.15,
+        "6" => 2.25,
+        "5" => 2.18,
+        "17" => 2.04,
+        "16" => 2.1,
+        "9" => 2.01,
+        "8" => 2.01,
+        "30" => 2.01,
+        "26" => 2.03,
+        "19" => 2.04,
+        "24" => 2.14,
+        "2" => 2.1,
+        "15" => 2.2,
+        "20" => 1.93,
+        "14" => 2.12,
+        "28" => 2.13,
+        "4" => 1.97,
+        "21" => 1.91,
+        "25" => 2.12,
+        "13" => 1.95,
+        "18" => 2.05,
+        "10" => 1.95,
+        "29" => 2.12,
+        "52" => 2.04,
+        "54" => 2.1,
+        "1" => 1.9,
+        "12" => 2.02,
+        "23" => 1.94,
+        "22" => 2.03,
+        "7" => 1.88,
+        "27" => 1.85,
+        "53" => 1.85
+      })
     assert_equal "6", @game_teams_manager.highest_scoring_visitor
   end
 
   def test_highest_scoring_home_team
-    @game_teams_manager.expects(:avg_goals_by_team).returns({"6"=>2.28,
-    "3"=>2.1,
-    "5"=>2.39,
-    "16"=>2.23,
-    "17"=>2.08,
-    "8"=>2.08,
-    "9"=>2.2,
-    "30"=>2.22,
-    "19"=>2.17,
-    "26"=>2.14,
-    "24"=>2.25,
-    "2"=>2.28,
-    "15"=>2.22,
-    "20"=>2.2,
-    "14"=>2.32,
-    "28"=>2.24,
-    "4"=>2.11,
-    "21"=>2.22,
-    "25"=>2.33,
-    "13"=>2.16,
-    "18"=>2.24,
-    "10"=>2.26,
-    "29"=>2.21,
-    "52"=>2.3,
-    "54"=>2.59,
-    "1"=>1.97,
-    "23"=>2.01,
-    "27"=>2.2,
-    "7"=>1.79,
-    "22"=>2.06,
-    "12"=>2.07,
-    "53"=>1.93})
+    @game_teams_manager.expects(:avg_goals_by_team).returns(
+      {
+        "6" => 2.28,
+        "3" => 2.1,
+        "5" => 2.39,
+        "16" => 2.23,
+        "17" => 2.08,
+        "8" => 2.08,
+        "9" => 2.2,
+        "30" => 2.22,
+        "19" => 2.17,
+        "26" => 2.14,
+        "24" => 2.25,
+        "2" => 2.28,
+        "15" => 2.22,
+        "20" => 2.2,
+        "14" => 2.32,
+        "28" => 2.24,
+        "4" => 2.11,
+        "21" => 2.22,
+        "25" => 2.33,
+        "13" => 2.16,
+        "18" => 2.24,
+        "10" => 2.26,
+        "29" => 2.21,
+        "52" => 2.3,
+        "54" => 2.59,
+        "1" => 1.97,
+        "23" => 2.01,
+        "27" => 2.2,
+        "7" => 1.79,
+        "22" => 2.06,
+        "12" => 2.07,
+        "53" => 1.93
+      })
     assert_equal "54", @game_teams_manager.highest_scoring_home_team
   end
 
   def test_lowest_scoring_visitor
-    @game_teams_manager.expects(:avg_goals_by_team).returns({"3"=>2.15,
-    "6"=>2.25,
-    "5"=>2.18,
-    "17"=>2.04,
-    "16"=>2.1,
-    "9"=>2.01,
-    "8"=>2.01,
-    "30"=>2.01,
-    "26"=>2.03,
-    "19"=>2.04,
-    "24"=>2.14,
-    "2"=>2.1,
-    "15"=>2.2,
-    "20"=>1.93,
-    "14"=>2.12,
-    "28"=>2.13,
-    "4"=>1.97,
-    "21"=>1.91,
-    "25"=>2.12,
-    "13"=>1.95,
-    "18"=>2.05,
-    "10"=>1.95,
-    "29"=>2.12,
-    "52"=>2.04,
-    "54"=>2.1,
-    "1"=>1.9,
-    "12"=>2.02,
-    "23"=>1.94,
-    "22"=>2.03,
-    "7"=>1.88,
-    "27"=>1.85,
-    "53"=>1.85})
+    @game_teams_manager.expects(:avg_goals_by_team).returns(
+      {
+        "3" => 2.15,
+        "6" => 2.25,
+        "5" => 2.18,
+        "17" => 2.04,
+        "16" => 2.1,
+        "9" => 2.01,
+        "8" => 2.01,
+        "30" => 2.01,
+        "26" => 2.03,
+        "19" => 2.04,
+        "24" => 2.14,
+        "2" => 2.1,
+        "15" => 2.2,
+        "20" => 1.93,
+        "14" => 2.12,
+        "28" => 2.13,
+        "4" => 1.97,
+        "21" => 1.91,
+        "25" => 2.12,
+        "13" => 1.95,
+        "18" => 2.05,
+        "10" => 1.95,
+        "29" => 2.12,
+        "52" => 2.04,
+        "54" => 2.1,
+        "1" => 1.9,
+        "12" => 2.02,
+        "23" => 1.94,
+        "22" => 2.03,
+        "7" => 1.88,
+        "27" => 1.85,
+        "53" => 1.85
+      })
     assert_equal "27", @game_teams_manager.lowest_scoring_visitor
   end
 
   def test_lowest_scoring_home_team
-    @game_teams_manager.expects(:avg_goals_by_team).returns({"6"=>2.28,
-    "3"=>2.1,
-    "5"=>2.39,
-    "16"=>2.23,
-    "17"=>2.08,
-    "8"=>2.08,
-    "9"=>2.2,
-    "30"=>2.22,
-    "19"=>2.17,
-    "26"=>2.14,
-    "24"=>2.25,
-    "2"=>2.28,
-    "15"=>2.22,
-    "20"=>2.2,
-    "14"=>2.32,
-    "28"=>2.24,
-    "4"=>2.11,
-    "21"=>2.22,
-    "25"=>2.33,
-    "13"=>2.16,
-    "18"=>2.24,
-    "10"=>2.26,
-    "29"=>2.21,
-    "52"=>2.3,
-    "54"=>2.59,
-    "1"=>1.97,
-    "23"=>2.01,
-    "27"=>2.2,
-    "7"=>1.79,
-    "22"=>2.06,
-    "12"=>2.07,
-    "53"=>1.93})
+    @game_teams_manager.expects(:avg_goals_by_team).returns(
+      {
+        "6" => 2.28,
+        "3" => 2.1,
+        "5" => 2.39,
+        "16" => 2.23,
+        "17" => 2.08,
+        "8" => 2.08,
+        "9" => 2.2,
+        "30" => 2.22,
+        "19" => 2.17,
+        "26" => 2.14,
+        "24" => 2.25,
+        "2" => 2.28,
+        "15" => 2.22,
+        "20" => 2.2,
+        "14" => 2.32,
+        "28" => 2.24,
+        "4" => 2.11,
+        "21" => 2.22,
+        "25" => 2.33,
+        "13" => 2.16,
+        "18" => 2.24,
+        "10" => 2.26,
+        "29" => 2.21,
+        "52" => 2.3,
+        "54" => 2.59,
+        "1" => 1.97,
+        "23" => 2.01,
+        "27" => 2.2,
+        "7" => 1.79,
+        "22" => 2.06,
+        "12" => 2.07,
+        "53" => 1.93
+      })
     assert_equal "7", @game_teams_manager.lowest_scoring_home_team
   end
 
@@ -251,53 +269,56 @@ class GameTeamsManagerTest < Minitest::Test
   end
 
   def test_it_gives_coach_stats
-    expected = {"John Tortorella"=>{:game_count=>2, :num_wins=>0}, "Claude Julien"=>{:game_count=>2, :num_wins=>2}}
+    expected = {"John Tortorella" => {:game_count => 2, :num_wins => 0},
+                "Claude Julien" => {:game_count => 2, :num_wins => 2}}
     assert_equal expected, @game_teams_manager.coach_stats([2012030222, 2012030223])
   end
 
   def test_winningest_coach
-    @game_teams_manager.expects(:coach_stats).returns({"John Tortorella"=>{:game_count=>2, :num_wins=>0}, "Claude Julien"=>{:game_count=>2, :num_wins=>2}})
-
+    @game_teams_manager.expects(:coach_stats).returns(
+      {"John Tortorella" => {:game_count => 2, :num_wins => 0},
+       "Claude Julien" => {:game_count => 2, :num_wins => 2}})
     assert_equal "Claude Julien", @game_teams_manager.winningest_coach([2012030222, 2012030223])
   end
 
   def test_worst_coach
-    @game_teams_manager.expects(:coach_stats).returns({"John Tortorella"=>{:game_count=>2, :num_wins=>0}, "Claude Julien"=>{:game_count=>2, :num_wins=>2}})
-
+    @game_teams_manager.expects(:coach_stats).returns(
+      {"John Tortorella" => {:game_count => 2, :num_wins => 0},
+       "Claude Julien" => {:game_count => 2, :num_wins => 2}})
     assert_equal "John Tortorella", @game_teams_manager.worst_coach([2012030222, 2012030223])
   end
 
   def test_team_goal_ratio
-    expected = {"3"=>{:goals=>3, :shots=>15}, "6"=>{:goals=>5, :shots=>16}}
+    expected = {"3" => {:goals => 3, :shots => 15}, "6" => {:goals => 5, :shots => 16}}
     assert_equal expected, @game_teams_manager.team_goal_ratio([2012030222, 2012030223])
   end
 
   def test_most_accurate_team
-    @game_teams_manager.expects(:team_goal_ratio).returns({"3"=>{:goals=>3, :shots=>15}, "6"=>{:goals=>5, :shots=>16}})
-
+    @game_teams_manager.expects(:team_goal_ratio).returns(
+      {"3" => {:goals => 3, :shots => 15},
+      "6"=> {:goals => 5, :shots => 16}})
     assert_equal "6", @game_teams_manager.most_accurate_team([2012030222, 2012030223])
   end
 
   def test_least_accurate_team
-    @game_teams_manager.expects(:team_goal_ratio).returns({"3"=>{:goals=>3, :shots=>15}, "6"=>{:goals=>5, :shots=>16}})
-
+    @game_teams_manager.expects(:team_goal_ratio).returns(
+      {"3" => {:goals => 3, :shots => 15},
+      "6" => {:goals => 5, :shots => 16}})
     assert_equal "3", @game_teams_manager.least_accurate_team([2012030222, 2012030223])
   end
 
   def test_total_tackles_by_team
-    expected = ({"3"=>70, "6"=>64})
+    expected = ({"3" => 70, "6" => 64})
     assert_equal expected, @game_teams_manager.total_tackles_by_team([2012030222, 2012030223])
   end
 
   def test_most_tackles
-    @game_teams_manager.expects(:total_tackles_by_team).returns({"3"=>70, "6"=>64})
-
+    @game_teams_manager.expects(:total_tackles_by_team).returns({"3" => 70, "6" => 64})
     assert_equal "3",  @game_teams_manager.most_tackles([2012030222, 2012030223])
   end
 
   def test_fewest_tackles
-    @game_teams_manager.expects(:total_tackles_by_team).returns({"3"=>70, "6"=>64})
-
+    @game_teams_manager.expects(:total_tackles_by_team).returns({"3" => 70, "6" => 64})
     assert_equal "6", @game_teams_manager.fewest_tackles([2012030222, 2012030223])
   end
 end

--- a/test/team_manager_test.rb
+++ b/test/team_manager_test.rb
@@ -3,7 +3,6 @@ require './lib/team'
 require './lib/team_manager'
 
 class TeamManagerTest < Minitest::Test
-
   def setup
     @team_manager = TeamManager.new('./data/teams.csv')
   end

--- a/test/team_test.rb
+++ b/test/team_test.rb
@@ -2,7 +2,6 @@ require './test/test_helper'
 require './lib/team'
 
 class TeamTest < Minitest::Test
-
   def setup
     @team_info = {"team_id" =>"1",
                   "franchiseId" =>"23",


### PR DESCRIPTION
- clean up class structure to follow ruby style guide
  - match whitespace & ordering conventions for modules, attr_readers & initialize
  - move stat_tracker class method `from_csv` ahead of `def initialize`
  - match whitespacing style of test files
- match indentation & whitespace style of hashes in game_teams_test
